### PR TITLE
Add variable expansion for dynamic paths

### DIFF
--- a/LNCHR-Commands.ahk
+++ b/LNCHR-Commands.ahk
@@ -199,21 +199,21 @@ lngui_run_commands(input)
     if (input == "fdesk") ; Folder desk
     {
         close_lngui()
-        tryrun('"C:\Users\' A_Username '\Desktop"')
+        tryrun('"C:\Users\%A_Username%\Desktop"')
         return
     }
 
     if (input == "fdoc") ; Folder My Documents
     {
         close_lngui()
-        tryrun('"C:\Users\' A_Username '\Documents"')
+        tryrun('"C:\Users\%A_Username%\Documents"')
         return
     }
 
     if (input == "fdown") ; Folder Downloads
     {
         close_lngui()
-        tryrun('"C:\Users\' A_Username '\Downloads"')
+        tryrun('"C:\Users\%A_Username%\Downloads"')
         return
     }
 
@@ -373,8 +373,7 @@ lngui_run_commands(input)
     if (input == "ont") ; OnTopReplica
     {
         close_lngui()
-        tryrun("C:\Users\" . A_Username .
-            "\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\OnTopReplica\OnTopReplica.lnk")
+        tryrun("C:\Users\%A_Username%\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\OnTopReplica\OnTopReplica.lnk")
         return
     }
 
@@ -634,7 +633,7 @@ lngui_run_commands(input)
     if (input == "vsc") ; Run Visual Studio Code
     {
         close_lngui()
-        TryRun("C:\Users\" . A_Username . "\AppData\Local\Programs\Microsoft VS Code\Code.exe")
+        TryRun("C:\Users\%A_Username%\AppData\Local\Programs\Microsoft VS Code\Code.exe")
         return
     }
 

--- a/LNCHR-Funcs.ahk
+++ b/LNCHR-Funcs.ahk
@@ -12,6 +12,7 @@
 
 
 TryRun(s) {
+    s := ExpandVars(s)
     try {
         run s
     }
@@ -20,6 +21,28 @@ TryRun(s) {
         ToolTip("failed to run:`n" s, 500, 0)
         SetTimer(() => ToolTip(), -3000)
     }
+}
+
+ExpandVars(str) {
+    return RegExReplace(str, "%([^%]+)%", ExpandVars_Callback)
+}
+
+ExpandVars_Callback(match) {
+    name := match[1]
+    val := ""
+    try val := %name%
+    catch {}
+    if (val == "")
+    {
+        try val := EnvGet(name)
+        catch {}
+    }
+    if (val == "")
+    {
+        try val := TryGetValueFromINIFile(name)
+        catch {}
+    }
+    return val
 }
 
 

--- a/commands.json
+++ b/commands.json
@@ -1,0 +1,7 @@
+{
+  "fdesk": "C:\\Users\\%A_Username%\\Desktop",
+  "fdoc": "C:\\Users\\%A_Username%\\Documents",
+  "fdown": "C:\\Users\\%A_Username%\\Downloads",
+  "ont": "C:\\Users\\%A_Username%\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\OnTopReplica\\OnTopReplica.lnk",
+  "vsc": "C:\\Users\\%A_Username%\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe"
+}


### PR DESCRIPTION
## Summary
- add `ExpandVars` helper in `LNCHR-Funcs.ahk`
- auto-expand variables when running commands
- update LNCHR command paths to use `%A_Username%`
- add sample `commands.json` with placeholders

## Testing
- `python3 -m json.tool commands.json`

------
https://chatgpt.com/codex/tasks/task_e_684c7a1aa4a08332b4f60ff583deee81